### PR TITLE
Remove dead code in FluNet service

### DIFF
--- a/backend/app/services/flunet.py
+++ b/backend/app/services/flunet.py
@@ -91,8 +91,6 @@ def _process_records(records: list) -> list[dict]:
     for rec in records:
         iso_year = rec.get("ISO_YEAR")
         iso_week = rec.get("ISO_WEEK")
-        country_raw = rec.get("COUNTRY_AREA_TERRITORY") or rec.get("ISO2", "")
-
         if not iso_year or not iso_week:
             continue
 


### PR DESCRIPTION
## Summary
- remove the unused `country_raw` variable from `_process_records` in `backend/app/services/flunet.py`
- keep behavior unchanged; this is a dead-code cleanup only

## Testing
- `docker compose run --rm backend pytest -q tests/test_flunet.py`
- `docker compose run --rm backend pytest -q`

Closes #6