### PR TITLE
Refactor repeated week cutoff calculations into shared utility

### DIFF
--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -1,0 +1,5 @@
+from datetime import date, timedelta
+
+
+def weeks_ago(reference_date: date, n: int) -> date:
+    return reference_date - timedelta(weeks=n)


### PR DESCRIPTION
## Summary

- add `weeks_ago(reference_date, n)` utility in `backend/app/utils.py`
- replace repeated `max_date - timedelta(weeks=N)` and `cutoff - timedelta(weeks=N)` patterns in `backend/app/routers/cases.py` with the shared helper

## Testing

- `pytest -q` (fails during collection: `ModuleNotFoundError: pytest_asyncio`)
- `python -m compileall backend/app`

Closes #18