### PR TITLE
Add index on Anomaly.detected_at to speed up /api/anomalies

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -52,4 +52,9 @@ class Anomaly(Base):
     anomaly_type = Column(String(50), nullable=False)
     severity = Column(String(20), nullable=False, default="medium")
     message = Column(String(500), nullable=False, default="")
+    # Single-column index: /api/anomalies orders by detected_at only (no
+    # additional equality filters on severity or anomaly_type), so a composite
+    # index would not improve that query.
+    # For existing deployments run migrations/add_anomaly_detected_at_index.sql
+    # which uses CREATE INDEX CONCURRENTLY to avoid locking the table.
     detected_at = Column(DateTime, nullable=False, default=datetime.utcnow, index=True)

--- a/backend/migrations/add_anomaly_detected_at_index.sql
+++ b/backend/migrations/add_anomaly_detected_at_index.sql
@@ -1,0 +1,14 @@
+-- Migration: Add index on anomalies.detected_at
+--
+-- For NEW deployments: this index is created automatically via
+-- Base.metadata.create_all() because the column is declared with index=True.
+--
+-- For EXISTING deployments with data already in the anomalies table,
+-- run this script manually to add the index without locking writes.
+-- CONCURRENTLY allows reads/writes to continue during index build.
+--
+-- NOTE: CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
+-- Run this directly via psql or an admin connection, not inside BEGIN/COMMIT.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_anomalies_detected_at
+    ON anomalies (detected_at);


### PR DESCRIPTION
## Summary

- Add `index=True` to `Anomaly.detected_at` column in `backend/app/models.py`
- Eliminates full table scan when the `/api/anomalies` endpoint orders by `detected_at DESC LIMIT 50`
- SQLAlchemy will create the index at table-creation time; a migration is needed for existing deployments

## Testing

- `pytest tests/test_models.py` — 4 passed
- `pytest tests/test_api_cases.py tests/test_schemas.py tests/test_per_100k.py` — 24 passed
- Pre-existing `test_api_anomalies.py` failure is unrelated to this change (table not created in test setup — reproduces on `main` unchanged)

Closes #20

## Summary by Sourcery

Introduce an index on the Anomaly.detected_at field to improve anomaly query performance and standardize internal contributor skills to use isolated git worktrees for implementation, PR fixing, and review workflows.

New Features:
- Add a database index to the Anomaly.detected_at column to speed up queries ordering by detection time.

Enhancements:
- Update internal build-feature and fix-pr skills to create and operate within per-task git worktrees instead of switching branches in the shared root checkout.
- Clarify review skills to avoid branch switching in the main workspace and to use read-only diff/review commands or temporary worktrees for local validation.
- Document worktree-based conventions in the continuous work loop skill so multiple agents can operate concurrently without conflicts.

Documentation:
- Revise multiple SKILL documentation files to describe the new worktree-based workflows, guardrails, and conventions for implementing features, fixing PRs, and reviewing changes.