### PR TITLE
Add query parameter validation bounds across API routers

### DIFF
--- a/backend/app/routers/cases.py
+++ b/backend/app/routers/cases.py
@@ -162,10 +162,10 @@ async def cases_subtypes():
 
 @router.get("/cases/countries", response_model=list[CountryRow])
 async def cases_countries(
-    search: str = Query("", description="Search filter"),
-    continent: str = Query("", description="Continent filter"),
-    flu_type: str = Query("", description="Flu type filter"),
-    sort: str = Query("cases", description="Sort field"),
+    search: str = Query("", max_length=64, description="Search filter"),
+    continent: str = Query("", max_length=32, description="Continent filter"),
+    flu_type: str = Query("", max_length=32, description="Flu type filter"),
+    sort: str = Query("cases", max_length=32, description="Sort field"),
 ):
     async with async_session() as session:
         max_date_r = await session.execute(select(func.max(FluCase.time)))

--- a/backend/app/routers/forecast.py
+++ b/backend/app/routers/forecast.py
@@ -6,7 +6,7 @@ router = APIRouter()
 
 @router.get("/forecast")
 async def get_forecast(
-    country: str = Query("", description="Country code filter"),
-    weeks: int = Query(8, description="Weeks to forecast"),
+    country: str = Query("", max_length=2, description="Country code filter"),
+    weeks: int = Query(8, ge=1, le=52, description="Weeks to forecast"),
 ):
     return await generate_forecast(country_code=country or None, weeks_ahead=weeks)

--- a/backend/app/routers/genomics.py
+++ b/backend/app/routers/genomics.py
@@ -10,9 +10,9 @@ router = APIRouter()
 
 @router.get("/trends", response_model=list[GenomicTrendPoint])
 async def genomic_trends(
-    years: int = Query(1, description="Years of data"),
-    country: str = Query("", description="Country filter"),
-    top_n: int = Query(6, description="Top N clades"),
+    years: int = Query(1, ge=1, le=10, description="Years of data"),
+    country: str = Query("", max_length=2, description="Country filter"),
+    top_n: int = Query(6, ge=1, le=100, description="Top N clades"),
 ):
     async with async_session() as session:
         cutoff = date.today() - timedelta(days=years * 365)


### PR DESCRIPTION
## Summary

- add bounded `Query(...)` validation for numeric params on API routes (`weeks`, `years`, `top_n`)
- add max-length constraints for string query params (`country`, `search`, `continent`, `flu_type`, `sort`) to reject oversized inputs

## Testing

- `python -m compileall backend/app`

Closes #14

## Summary by Sourcery

Add validation bounds for numeric and string query parameters across forecast, cases, and genomics API endpoints to constrain input size and range.

New Features:
- Introduce bounded numeric query parameters for years, weeks, and top_n on genomics and forecast endpoints.
- Add maximum length constraints to string query parameters such as country, search, continent, flu_type, and sort on relevant API routes.