### PR TITLE
Deduplicate shared Country/Genomics table styles

### DIFF
--- a/frontend/src/components/CountryTable.jsx
+++ b/frontend/src/components/CountryTable.jsx
@@ -1,13 +1,9 @@
 import React, { useState } from 'react'
 import { severityColor } from '../utils/colors'
+import { cardContainerStyle, tableStyles } from '../utils/tableStyles'
 
 const styles = {
-  container: {
-    background: '#0d1117',
-    borderRadius: 8,
-    padding: 16,
-    border: '1px solid #2a2a4a',
-  },
+  container: cardContainerStyle,
   controls: {
     display: 'flex',
     gap: 8,
@@ -22,23 +18,12 @@ const styles = {
     padding: '6px 12px',
     fontSize: '0.8rem',
   },
-  table: {
-    width: '100%',
-    borderCollapse: 'collapse',
-    fontSize: '0.8rem',
-  },
   th: {
-    textAlign: 'left',
-    padding: '8px 12px',
-    borderBottom: '1px solid #333',
-    color: '#888',
-    fontWeight: 600,
+    ...tableStyles.th,
     cursor: 'pointer',
   },
-  td: {
-    padding: '8px 12px',
-    borderBottom: '1px solid #1a1a2e',
-  },
+  table: tableStyles.table,
+  td: tableStyles.td,
 }
 
 function Sparkline({ data, width = 80, height = 20 }) {

--- a/frontend/src/components/GenomicsTable.jsx
+++ b/frontend/src/components/GenomicsTable.jsx
@@ -1,33 +1,28 @@
 import React from 'react'
-
-const styles = {
-  table: { width: '100%', borderCollapse: 'collapse', fontSize: '0.8rem' },
-  th: { textAlign: 'left', padding: '8px 12px', borderBottom: '1px solid #333', color: '#888', fontWeight: 600 },
-  td: { padding: '8px 12px', borderBottom: '1px solid #1a1a2e', color: '#ccc' },
-}
+import { cardContainerStyle, tableStyles } from '../utils/tableStyles'
 
 export default function GenomicsTable({ data }) {
   if (!data || data.length === 0) return null
 
   return (
-    <div style={{ background: '#0d1117', borderRadius: 8, padding: 16, border: '1px solid #2a2a4a' }}>
+    <div style={cardContainerStyle}>
       <h3 style={{ fontSize: '0.9rem', color: '#ccc', marginBottom: 12 }}>Top Countries by Sequences</h3>
-      <table style={styles.table}>
+      <table style={tableStyles.table}>
         <thead>
           <tr>
-            <th style={styles.th}>#</th>
-            <th style={styles.th}>Country</th>
-            <th style={styles.th}>Sequences</th>
-            <th style={styles.th}>Top Clade</th>
+            <th style={tableStyles.th}>#</th>
+            <th style={tableStyles.th}>Country</th>
+            <th style={tableStyles.th}>Sequences</th>
+            <th style={tableStyles.th}>Top Clade</th>
           </tr>
         </thead>
         <tbody>
           {data.map((r, i) => (
             <tr key={r.country_code}>
-              <td style={styles.td}>{i + 1}</td>
-              <td style={styles.td}>{r.country_code}</td>
-              <td style={styles.td}>{r.total_sequences?.toLocaleString()}</td>
-              <td style={styles.td}>{r.top_clade}</td>
+              <td style={{ ...tableStyles.td, color: '#ccc' }}>{i + 1}</td>
+              <td style={{ ...tableStyles.td, color: '#ccc' }}>{r.country_code}</td>
+              <td style={{ ...tableStyles.td, color: '#ccc' }}>{r.total_sequences?.toLocaleString()}</td>
+              <td style={{ ...tableStyles.td, color: '#ccc' }}>{r.top_clade}</td>
             </tr>
           ))}
         </tbody>

--- a/frontend/src/utils/tableStyles.js
+++ b/frontend/src/utils/tableStyles.js
@@ -1,0 +1,25 @@
+export const tableStyles = {
+  table: {
+    width: '100%',
+    borderCollapse: 'collapse',
+    fontSize: '0.8rem',
+  },
+  th: {
+    textAlign: 'left',
+    padding: '8px 12px',
+    borderBottom: '1px solid #333',
+    color: '#888',
+    fontWeight: 600,
+  },
+  td: {
+    padding: '8px 12px',
+    borderBottom: '1px solid #1a1a2e',
+  },
+}
+
+export const cardContainerStyle = {
+  background: '#0d1117',
+  borderRadius: 8,
+  padding: 16,
+  border: '1px solid #2a2a4a',
+}


### PR DESCRIPTION
## Summary

- extract shared table/card styles into `frontend/src/utils/tableStyles.js`
- update `CountryTable` and `GenomicsTable` to import shared styles instead of duplicating inline table style objects

## Testing

- `npm run build`

Closes #17

## Summary by Sourcery

Deduplicate shared table and card styling for country and genomics tables into a shared utility and update both components to consume the centralized styles.

Enhancements:
- Extract shared table and card styles into a new frontend/src/utils/tableStyles.js module.
- Update CountryTable and GenomicsTable components to reuse the shared table and card styles instead of duplicating inline style definitions.