### PR TITLE
Deduplicate Clade/Subtype trends with shared StackedAreaChart

### DIFF
--- a/frontend/src/components/CladeTrends.jsx
+++ b/frontend/src/components/CladeTrends.jsx
@@ -1,92 +1,21 @@
-import React, { useRef, useEffect } from 'react'
-import * as d3 from 'd3'
+import React from 'react'
 import { cladeColors } from '../utils/colors'
 import { Link } from 'react-router-dom'
+import StackedAreaChart from './StackedAreaChart'
 
 export default function CladeTrends({ data }) {
-  const svgRef = useRef()
+  const clades = [...new Set((data || []).map((d) => d.clade))]
 
-  useEffect(() => {
-    if (!data || data.length === 0) return
-
-    const width = 500
-    const height = 280
-    const margin = { top: 20, right: 120, bottom: 40, left: 60 }
-
-    const svg = d3.select(svgRef.current)
-    svg.selectAll('*').remove()
-    svg.attr('viewBox', `0 0 ${width} ${height}`)
-
-    const clades = [...new Set(data.map(d => d.clade))]
-    const dates = [...new Set(data.map(d => d.date))].sort()
-
-    const matrix = dates.map(date => {
-      const row = { date: new Date(date) }
-      clades.forEach(c => { row[c] = 0 })
-      data.filter(d => d.date === date).forEach(d => { row[d.clade] = d.count })
-      return row
-    })
-
-    const stack = d3.stack().keys(clades)
-    const stacked = stack(matrix)
-
-    const x = d3.scaleTime()
-      .domain(d3.extent(matrix, d => d.date))
-      .range([margin.left, width - margin.right])
-
-    const y = d3.scaleLinear()
-      .domain([0, d3.max(stacked[stacked.length - 1] || [[0,0]], d => d[1]) || 1])
-      .range([height - margin.bottom, margin.top])
-
-    svg.append('g')
-      .attr('transform', `translate(0,${height - margin.bottom})`)
-      .call(d3.axisBottom(x).ticks(6))
-      .attr('color', '#666')
-
-    svg.append('g')
-      .attr('transform', `translate(${margin.left},0)`)
-      .call(d3.axisLeft(y).ticks(5).tickFormat(d3.format('.2s')))
-      .attr('color', '#666')
-
-    const area = d3.area()
-      .x((d, i) => x(matrix[i].date))
-      .y0(d => y(d[0]))
-      .y1(d => y(d[1]))
-      .curve(d3.curveMonotoneX)
-
-    svg.selectAll('.layer')
-      .data(stacked)
-      .join('path')
-      .attr('class', 'layer')
-      .attr('d', area)
-      .attr('fill', d => cladeColors(d.key))
-      .attr('opacity', 0.8)
-
-    // Legend
-    clades.forEach((c, i) => {
-      svg.append('rect')
-        .attr('x', width - margin.right + 8)
-        .attr('y', margin.top + i * 18)
-        .attr('width', 12).attr('height', 12)
-        .attr('fill', cladeColors(c))
-      svg.append('text')
-        .attr('x', width - margin.right + 24)
-        .attr('y', margin.top + i * 18 + 10)
-        .attr('fill', '#ccc')
-        .attr('font-size', '0.6rem')
-        .text(c)
-    })
-  }, [data])
-
-  return (
-    <div style={{ background: '#0d1117', borderRadius: 8, padding: 12, border: '1px solid #2a2a4a' }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
-        <h3 style={{ fontSize: '0.9rem', color: '#ccc' }}>Clade Trends (1 year)</h3>
-        <Link to="/genomics" style={{ fontSize: '0.75rem', color: '#f59e0b', textDecoration: 'none' }}>
-          View Genomics Dashboard →
-        </Link>
-      </div>
-      <svg ref={svgRef} style={{ width: '100%', height: 'auto' }} />
-    </div>
-  )
+  return <StackedAreaChart
+    data={data}
+    keys={clades}
+    colorScale={cladeColors}
+    xAccessor={(d) => d.date}
+    yAccessor={(d) => d.count}
+    seriesAccessor={(d) => d.clade}
+    title="Clade Trends (1 year)"
+    headerAction={<Link to="/genomics" style={{ fontSize: '0.75rem', color: '#f59e0b', textDecoration: 'none' }}>
+      View Genomics Dashboard →
+    </Link>}
+  />
 }

--- a/frontend/src/components/StackedAreaChart.jsx
+++ b/frontend/src/components/StackedAreaChart.jsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useRef } from 'react'
+import * as d3 from 'd3'
+
+const CARD_STYLE = { background: '#0d1117', borderRadius: 8, padding: 12, border: '1px solid #2a2a4a' }
+
+function resolveColor(colorScale, key) {
+  if (typeof colorScale === 'function') return colorScale(key)
+  return colorScale?.[key] || '#666'
+}
+
+export default function StackedAreaChart({
+  data,
+  keys,
+  colorScale,
+  xAccessor,
+  yAccessor,
+  seriesAccessor,
+  title,
+  headerAction = null,
+}) {
+  const svgRef = useRef()
+
+  useEffect(() => {
+    if (!data || data.length === 0 || !keys || keys.length === 0) return
+
+    const width = 500
+    const height = 280
+    const margin = { top: 20, right: 120, bottom: 40, left: 60 }
+
+    const svg = d3.select(svgRef.current)
+    svg.selectAll('*').remove()
+    svg.attr('viewBox', `0 0 ${width} ${height}`)
+
+    const dateStrings = [...new Set(data.map((d) => String(xAccessor(d))))].sort()
+    const matrix = dateStrings.map((dateStr) => {
+      const row = { date: new Date(dateStr) }
+      keys.forEach((k) => {
+        row[k] = 0
+      })
+      return row
+    })
+    const rowByDate = Object.fromEntries(dateStrings.map((d, i) => [d, matrix[i]]))
+
+    data.forEach((point) => {
+      const dateStr = String(xAccessor(point))
+      const key = seriesAccessor(point)
+      const row = rowByDate[dateStr]
+      if (row && keys.includes(key)) {
+        row[key] = yAccessor(point)
+      }
+    })
+
+    const stacked = d3.stack().keys(keys)(matrix)
+
+    const x = d3.scaleTime()
+      .domain(d3.extent(matrix, (d) => d.date))
+      .range([margin.left, width - margin.right])
+
+    const y = d3.scaleLinear()
+      .domain([0, d3.max(stacked[stacked.length - 1] || [[0, 0]], (d) => d[1]) || 1])
+      .range([height - margin.bottom, margin.top])
+
+    svg.append('g')
+      .attr('transform', `translate(0,${height - margin.bottom})`)
+      .call(d3.axisBottom(x).ticks(6))
+      .attr('color', '#666')
+
+    svg.append('g')
+      .attr('transform', `translate(${margin.left},0)`)
+      .call(d3.axisLeft(y).ticks(5).tickFormat(d3.format('.2s')))
+      .attr('color', '#666')
+
+    const area = d3.area()
+      .x((_, i) => x(matrix[i].date))
+      .y0((d) => y(d[0]))
+      .y1((d) => y(d[1]))
+      .curve(d3.curveMonotoneX)
+
+    svg.selectAll('.layer')
+      .data(stacked)
+      .join('path')
+      .attr('class', 'layer')
+      .attr('d', area)
+      .attr('fill', (d) => resolveColor(colorScale, d.key))
+      .attr('opacity', 0.8)
+
+    keys.forEach((key, i) => {
+      svg.append('rect')
+        .attr('x', width - margin.right + 8)
+        .attr('y', margin.top + i * 18)
+        .attr('width', 12)
+        .attr('height', 12)
+        .attr('fill', resolveColor(colorScale, key))
+      svg.append('text')
+        .attr('x', width - margin.right + 24)
+        .attr('y', margin.top + i * 18 + 10)
+        .attr('fill', '#ccc')
+        .attr('font-size', '0.6rem')
+        .text(key)
+    })
+  }, [colorScale, data, keys, seriesAccessor, xAccessor, yAccessor])
+
+  return (
+    <div style={CARD_STYLE}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+        <h3 style={{ fontSize: '0.9rem', color: '#ccc' }}>{title}</h3>
+        {headerAction}
+      </div>
+      <svg ref={svgRef} style={{ width: '100%', height: 'auto' }} />
+    </div>
+  )
+}

--- a/frontend/src/components/SubtypeTrends.jsx
+++ b/frontend/src/components/SubtypeTrends.jsx
@@ -1,87 +1,17 @@
-import React, { useRef, useEffect } from 'react'
-import * as d3 from 'd3'
+import React from 'react'
 import { subtypeColors } from '../utils/colors'
+import StackedAreaChart from './StackedAreaChart'
 
 export default function SubtypeTrends({ data }) {
-  const svgRef = useRef()
+  const subtypes = [...new Set((data || []).map((d) => d.subtype))]
 
-  useEffect(() => {
-    if (!data || data.length === 0) return
-
-    const width = 500
-    const height = 280
-    const margin = { top: 20, right: 120, bottom: 40, left: 60 }
-
-    const svg = d3.select(svgRef.current)
-    svg.selectAll('*').remove()
-    svg.attr('viewBox', `0 0 ${width} ${height}`)
-
-    const subtypes = [...new Set(data.map(d => d.subtype))]
-    const dates = [...new Set(data.map(d => d.date))].sort()
-
-    // Build matrix
-    const matrix = dates.map(date => {
-      const row = { date: new Date(date) }
-      subtypes.forEach(s => { row[s] = 0 })
-      data.filter(d => d.date === date).forEach(d => { row[d.subtype] = d.cases })
-      return row
-    })
-
-    const stack = d3.stack().keys(subtypes)
-    const stacked = stack(matrix)
-
-    const x = d3.scaleTime()
-      .domain(d3.extent(matrix, d => d.date))
-      .range([margin.left, width - margin.right])
-
-    const y = d3.scaleLinear()
-      .domain([0, d3.max(stacked[stacked.length - 1] || [[0,0]], d => d[1]) || 1])
-      .range([height - margin.bottom, margin.top])
-
-    svg.append('g')
-      .attr('transform', `translate(0,${height - margin.bottom})`)
-      .call(d3.axisBottom(x).ticks(6))
-      .attr('color', '#666')
-
-    svg.append('g')
-      .attr('transform', `translate(${margin.left},0)`)
-      .call(d3.axisLeft(y).ticks(5).tickFormat(d3.format('.2s')))
-      .attr('color', '#666')
-
-    const area = d3.area()
-      .x((d, i) => x(matrix[i].date))
-      .y0(d => y(d[0]))
-      .y1(d => y(d[1]))
-      .curve(d3.curveMonotoneX)
-
-    svg.selectAll('.layer')
-      .data(stacked)
-      .join('path')
-      .attr('class', 'layer')
-      .attr('d', area)
-      .attr('fill', d => subtypeColors[d.key] || '#666')
-      .attr('opacity', 0.8)
-
-    // Legend
-    subtypes.forEach((s, i) => {
-      svg.append('rect')
-        .attr('x', width - margin.right + 8)
-        .attr('y', margin.top + i * 18)
-        .attr('width', 12).attr('height', 12)
-        .attr('fill', subtypeColors[s] || '#666')
-      svg.append('text')
-        .attr('x', width - margin.right + 24)
-        .attr('y', margin.top + i * 18 + 10)
-        .attr('fill', '#ccc')
-        .attr('font-size', '0.6rem')
-        .text(s)
-    })
-  }, [data])
-
-  return (
-    <div style={{ background: '#0d1117', borderRadius: 8, padding: 12, border: '1px solid #2a2a4a' }}>
-      <h3 style={{ fontSize: '0.9rem', color: '#ccc', marginBottom: 8 }}>Subtype Trends (1 year)</h3>
-      <svg ref={svgRef} style={{ width: '100%', height: 'auto' }} />
-    </div>
-  )
+  return <StackedAreaChart
+    data={data}
+    keys={subtypes}
+    colorScale={subtypeColors}
+    xAccessor={(d) => d.date}
+    yAccessor={(d) => d.cases}
+    seriesAccessor={(d) => d.subtype}
+    title="Subtype Trends (1 year)"
+  />
 }


### PR DESCRIPTION
## Summary

- add reusable `StackedAreaChart` component to centralize stacked-area D3 rendering logic
- replace duplicated implementations in `CladeTrends` and `SubtypeTrends` with wrapper usage of the shared component
- keep component-specific behavior via accessors and color scale inputs

## Testing

- `npm run build`

Closes #16

## Summary by Sourcery

Deduplicate clade and subtype trend visualizations by introducing a shared stacked area chart component and updating existing trend views to use it.

New Features:
- Add a reusable StackedAreaChart React component for rendering stacked area D3 charts with configurable accessors and color scales.

Enhancements:
- Refactor CladeTrends to render via the shared StackedAreaChart while preserving clade-specific colors and header action link.
- Refactor SubtypeTrends to use the shared StackedAreaChart with subtype-specific keys and color mapping.