### PR TITLE
Add default API rate limiting with SlowAPI

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,10 @@ import logging
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
+from slowapi.util import get_remote_address
 from app.scheduler import create_scheduler, init_db, run_startup_jobs
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
@@ -25,6 +29,9 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(title="FluTracker API", lifespan=lifespan)
+limiter = Limiter(key_func=get_remote_address, default_limits=["60/minute"])
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 app.add_middleware(
     CORSMiddleware,
@@ -33,6 +40,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.add_middleware(SlowAPIMiddleware)
 
 # Import and include routers
 from app.routers import cases, genomics, anomalies, forecast as forecast_router

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ uvicorn[standard]==0.34.0
 sqlalchemy[asyncio]==2.0.36
 asyncpg==0.30.0
 httpx==0.28.1
+slowapi==0.1.9
 apscheduler==3.10.4
 pydantic-settings==2.7.0
 numpy==2.2.1

--- a/backend/tests/test_api_rate_limit.py
+++ b/backend/tests/test_api_rate_limit.py
@@ -1,0 +1,14 @@
+"""Tests for API rate limiting."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_rate_limited(client):
+    status_codes = []
+    for _ in range(70):
+        resp = await client.get("/api/health")
+        status_codes.append(resp.status_code)
+
+    assert 200 in status_codes
+    assert 429 in status_codes


### PR DESCRIPTION
## Summary

- add SlowAPI limiter setup in `backend/app/main.py` with a default `60/minute` per-client limit
- register the SlowAPI exception handler and middleware so limits are enforced across API routes
- add a focused API test that verifies rate-limit responses are returned

## Testing

- `DATABASE_URL=sqlite+aiosqlite:///:memory: python -m pytest backend/tests/test_api_health.py backend/tests/test_api_rate_limit.py`
- `DATABASE_URL=sqlite+aiosqlite:///:memory: python -m pytest backend/tests/test_per_100k.py backend/tests/test_api_cases.py backend/tests/test_api_anomalies.py backend/tests/test_api_genomics.py backend/tests/test_api_forecast.py backend/tests/test_api_health.py backend/tests/test_api_rate_limit.py`

Closes #27

## Summary by Sourcery

Introduce default per-client API rate limiting and validate it with tests.

New Features:
- Add a global API rate limiter with a default 60-requests-per-minute per-client limit.

Build:
- Add SlowAPI as a backend dependency for request rate limiting.

Tests:
- Add an async API test ensuring the health endpoint enforces rate limiting and returns HTTP 429 after sufficient requests.