### PR TITLE
Use Python enums for flu/anomaly type and severity constants

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,6 +1,37 @@
-from sqlalchemy import Column, Integer, String, Date, DateTime, Float, UniqueConstraint
-from sqlalchemy.orm import DeclarativeBase
+import enum
 from datetime import datetime
+
+from sqlalchemy import (
+    Column,
+    Date,
+    DateTime,
+    Enum as SAEnum,
+    Integer,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import DeclarativeBase
+
+
+class FluType(str, enum.Enum):
+    H1N1 = "H1N1"
+    H3N2 = "H3N2"
+    H5N1 = "H5N1"
+    H7N9 = "H7N9"
+    B_YAMAGATA = "B/Yamagata"
+    B_VICTORIA = "B/Victoria"
+    A_UNSUBTYPED = "A (unsubtyped)"
+    B_LINEAGE_UNKNOWN = "B (lineage unknown)"
+    UNKNOWN = "unknown"
+
+
+class AnomalyType(str, enum.Enum):
+    SPIKE = "spike"
+
+
+class Severity(str, enum.Enum):
+    HIGH = "high"
+    MEDIUM = "medium"
 
 
 class Base(DeclarativeBase):
@@ -14,7 +45,7 @@ class FluCase(Base):
     country_code = Column(String(10), nullable=False, index=True)
     region = Column(String(100), default="")
     city = Column(String(100), default="")
-    flu_type = Column(String(50), nullable=False)
+    flu_type = Column(SAEnum(FluType, native_enum=False), nullable=False)
     source = Column(String(50), nullable=False, default="who_flunet")
     time = Column(Date, nullable=False, index=True)
     new_cases = Column(Integer, nullable=False, default=0)
@@ -49,8 +80,12 @@ class Anomaly(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     country_code = Column(String(10), nullable=False)
     country_name = Column(String(200), nullable=False, default="")
-    anomaly_type = Column(String(50), nullable=False)
-    severity = Column(String(20), nullable=False, default="medium")
+    anomaly_type = Column(SAEnum(AnomalyType, native_enum=False), nullable=False)
+    severity = Column(
+        SAEnum(Severity, native_enum=False),
+        nullable=False,
+        default=Severity.MEDIUM,
+    )
     message = Column(String(500), nullable=False, default="")
     # Single-column index: /api/anomalies orders by detected_at only (no
     # additional equality filters on severity or anomaly_type), so a composite

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 from datetime import date, datetime
 from typing import Optional
+from app.models import AnomalyType, Severity
 
 
 class CaseSummary(BaseModel):
@@ -48,8 +49,8 @@ class AnomalyOut(BaseModel):
     id: int
     country_code: str
     country_name: str
-    anomaly_type: str
-    severity: str
+    anomaly_type: AnomalyType
+    severity: Severity
     message: str
     detected_at: datetime
 

--- a/backend/app/services/anomaly.py
+++ b/backend/app/services/anomaly.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime, timedelta
 from sqlalchemy import select, func, delete, text
 from app.database import async_session
-from app.models import FluCase, Anomaly
+from app.models import Anomaly, AnomalyType, FluCase, Severity
 
 logger = logging.getLogger(__name__)
 
@@ -69,11 +69,11 @@ async def detect_anomalies():
                 zscore = (weekly_avg - avg) / std
 
                 if zscore >= ZSCORE_THRESHOLD:
-                    severity = "high" if zscore >= 3.0 else "medium"
+                    severity = Severity.HIGH if zscore >= 3.0 else Severity.MEDIUM
                     anomalies.append(Anomaly(
                         country_code=cc,
                         country_name=cc,
-                        anomaly_type="spike",
+                        anomaly_type=AnomalyType.SPIKE,
                         severity=severity,
                         message=f"{cc}: cases {zscore:.1f}x std above mean ({int(weekly_avg)} vs avg {int(avg)})",
                         detected_at=datetime.utcnow(),


### PR DESCRIPTION
## Summary

- add shared Python enums (FluType, AnomalyType, Severity) in backend/app/models.py
- switch SQLAlchemy columns FluCase.flu_type, Anomaly.anomaly_type, and Anomaly.severity to SAEnum(..., native_enum=False)
- update schema and anomaly service code to use enum types instead of raw string literals

## Testing

- DATABASE_URL=sqlite+aiosqlite:///./test.db pytest backend/tests/test_models.py backend/tests/test_schemas.py backend/tests/test_service_anomaly.py backend/tests/test_api_anomalies.py
- DATABASE_URL=sqlite+aiosqlite:///./test.db pytest backend/tests/test_api_cases.py backend/tests/test_service_forecast.py backend/tests/test_flunet.py

Closes #25