### PR TITLE
Add error UI states to dashboard components when API calls fail

### DIFF
--- a/frontend/src/components/AlertBar.jsx
+++ b/frontend/src/components/AlertBar.jsx
@@ -32,7 +32,15 @@ const styles = {
   empty: { fontSize: '0.8rem', color: '#666' },
 }
 
-export default function AlertBar({ anomalies }) {
+export default function AlertBar({ anomalies, loadError }) {
+  if (loadError) {
+    return (
+      <div style={styles.bar}>
+        <span style={{ ...styles.empty, color: '#f87171' }}>Unable to load anomaly alerts — please refresh.</span>
+      </div>
+    )
+  }
+
   if (!anomalies || anomalies.length === 0) {
     return (
       <div style={styles.bar}>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -19,23 +19,42 @@ const grid2 = {
   marginBottom: 16,
 }
 
+function ErrorCard({ message }) {
+  return (
+    <div style={{
+      background: '#1a1a2e',
+      borderRadius: 8,
+      padding: '16px',
+      border: '1px solid #2a2a4a',
+      color: '#f87171',
+      fontSize: '0.85rem',
+    }}>
+      {message}
+    </div>
+  )
+}
+
 export default function Dashboard() {
-  const { data: summary } = useApi(() => api.summary(), [])
-  const { data: mapData } = useApi(() => api.mapData(), [])
-  const { data: historical } = useApi(() => api.historical(), [])
-  const { data: subtypes } = useApi(() => api.subtypes(), [])
-  const { data: countries } = useApi(() => api.countries(), [])
-  const { data: anomalies } = useApi(() => api.anomalies(), [])
-  const { data: forecast } = useApi(() => api.forecast(), [])
-  const { data: cladeTrends } = useApi(() => api.genomicTrends(), [])
+  const { data: summary, error: summaryError } = useApi(() => api.summary(), [])
+  const { data: mapData, error: mapError } = useApi(() => api.mapData(), [])
+  const { data: historical, error: historicalError } = useApi(() => api.historical(), [])
+  const { data: subtypes, error: subtypesError } = useApi(() => api.subtypes(), [])
+  const { data: countries, error: countriesError } = useApi(() => api.countries(), [])
+  const { data: anomalies, error: anomaliesError } = useApi(() => api.anomalies(), [])
+  const { data: forecast, error: forecastError } = useApi(() => api.forecast(), [])
+  const { data: cladeTrends, error: cladeTrendsError } = useApi(() => api.genomicTrends(), [])
 
   return (
     <div style={{ minHeight: '100vh', background: '#0a0a0f' }}>
       <Header lastUpdated={summary ? new Date().toISOString() : null} />
-      <AlertBar anomalies={anomalies} />
+      <AlertBar anomalies={anomalies} loadError={anomaliesError} />
 
       {/* Summary KPIs */}
-      {summary && (
+      {summaryError ? (
+        <div style={{ padding: '16px 24px' }}>
+          <ErrorCard message="Failed to load summary data — please refresh." />
+        </div>
+      ) : summary && (
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 12, padding: '16px 24px' }}>
           <KpiCard label="Total Cases" value={summary.total_cases?.toLocaleString()} />
           <KpiCard label="Countries Reporting" value={summary.countries_reporting} />
@@ -50,25 +69,25 @@ export default function Dashboard() {
 
       {/* Main grid: Map + Historical */}
       <div style={grid2}>
-        <ChoroplethMap data={mapData} />
-        <HistoricalChart data={historical} />
+        {mapError ? <ErrorCard message="Failed to load map data — please refresh." /> : <ChoroplethMap data={mapData} />}
+        {historicalError ? <ErrorCard message="Failed to load historical data — please refresh." /> : <HistoricalChart data={historical} />}
       </div>
 
       {/* Compare + Forecast */}
       <div style={grid2}>
         <CompareChart />
-        <ForecastChart data={forecast} />
+        {forecastError ? <ErrorCard message="Failed to load forecast data — please refresh." /> : <ForecastChart data={forecast} />}
       </div>
 
       {/* Secondary: Clade + Subtype */}
       <div style={grid2}>
-        <CladeTrends data={cladeTrends} />
-        <SubtypeTrends data={subtypes} />
+        {cladeTrendsError ? <ErrorCard message="Failed to load clade trend data — please refresh." /> : <CladeTrends data={cladeTrends} />}
+        {subtypesError ? <ErrorCard message="Failed to load subtype data — please refresh." /> : <SubtypeTrends data={subtypes} />}
       </div>
 
       {/* Country table */}
       <div style={{ padding: '0 24px 24px' }}>
-        <CountryTable data={countries} />
+        {countriesError ? <ErrorCard message="Failed to load country data — please refresh." /> : <CountryTable data={countries} />}
       </div>
 
       {/* Footer */}

--- a/frontend/src/pages/Genomics.jsx
+++ b/frontend/src/pages/Genomics.jsx
@@ -12,9 +12,9 @@ export default function Genomics() {
   const [topN, setTopN] = useState(6)
 
   const params = `years=${years}&top_n=${topN}${country ? `&country=${country}` : ''}`
-  const { data: trends } = useApi(() => api.genomicTrends(params), [years, country, topN])
-  const { data: summary } = useApi(() => api.genomicSummary(), [])
-  const { data: countries } = useApi(() => api.genomicCountries(), [])
+  const { data: trends, error: trendsError } = useApi(() => api.genomicTrends(params), [years, country, topN])
+  const { data: summary, error: summaryError } = useApi(() => api.genomicSummary(), [])
+  const { data: countries, error: countriesError } = useApi(() => api.genomicCountries(), [])
 
   const btnStyle = (active) => ({
     padding: '6px 14px',
@@ -72,17 +72,23 @@ export default function Genomics() {
 
       {/* KPIs */}
       <div style={{ padding: '0 24px 16px' }}>
-        <KpiCards data={summary} />
+        {summaryError
+          ? <p style={{ color: '#f87171', fontSize: '0.85rem' }}>Failed to load genomics summary — please refresh.</p>
+          : <KpiCards data={summary} />}
       </div>
 
       {/* Clade trends chart */}
       <div style={{ padding: '0 24px 16px' }}>
-        <CladeTrends data={trends} />
+        {trendsError
+          ? <p style={{ color: '#f87171', fontSize: '0.85rem' }}>Failed to load trend data — please refresh.</p>
+          : <CladeTrends data={trends} />}
       </div>
 
       {/* Countries table */}
       <div style={{ padding: '0 24px 24px' }}>
-        <GenomicsTable data={countries} />
+        {countriesError
+          ? <p style={{ color: '#f87171', fontSize: '0.85rem' }}>Failed to load countries data — please refresh.</p>
+          : <GenomicsTable data={countries} />}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- **Dashboard.jsx**: Extract `error` from all `useApi` calls; render an `ErrorCard` placeholder in each dashboard section (KPIs, map, historical, forecast, clade trends, subtype trends, country table) when the corresponding API call fails.
- **AlertBar.jsx**: Accept a `loadError` prop; show "Unable to load anomaly alerts — please refresh." when the anomalies fetch fails, distinguishing a load failure from "no anomalies".
- **Genomics.jsx**: Extract `error` from `useApi` calls for trends, summary, and countries; render inline error messages in each section on failure.

## Testing

- `npm run build` → ✓ built in 1.45s (629 modules)

Closes #22

## Summary by Sourcery

Add visible error handling states to dashboard and genomics pages when API requests fail, including dedicated error UI for anomalies in the alert bar.

New Features:
- Show section-specific error placeholders on the main dashboard when summary, map, historical, forecast, clade trends, subtype trends, or country data fail to load.
- Display a dedicated error state in the anomalies alert bar when the anomalies API request fails, distinct from the empty state.
- Render inline error messages in genomics KPIs, clade trends, and countries table when their respective API calls fail.