### PR TITLE
fix(skills): exclude in-flight issues from workload balancing

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -25,12 +25,15 @@ Use `gh` to submit the issue and return the URL.
 
 - Bug: `bug`
 - Feature request: `enhancement`
-- Balance workload between agents by checking open issue counts:
+- Balance workload between agents by counting only *actionable* open issues
+  (exclude issues already in the review cycle via `needs-review` or `needs:changes`):
   ```
-  gh issue list --label assigned:claude --state open --json number | jq length
-  gh issue list --label assigned:codex --state open --json number | jq length
+  gh issue list --label assigned:claude --state open --json number,labels \
+    | jq '[.[] | select(.labels | map(.name) | (contains(["needs-review"]) or contains(["needs:changes"])) | not)] | length'
+  gh issue list --label assigned:codex --state open --json number,labels \
+    | jq '[.[] | select(.labels | map(.name) | (contains(["needs-review"]) or contains(["needs:changes"])) | not)] | length'
   ```
-  Assign to whichever agent has fewer open issues (`assigned:claude` or `assigned:codex`).
+  Assign to whichever agent has fewer actionable open issues.
   Break ties by assigning to `assigned:claude`.
 - Add any other relevant labels that already exist in the repo (check with `gh label list`).
 

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -25,12 +25,15 @@ Use `gh` to submit the issue and return the URL.
 
 - Bug: `bug`
 - Feature request: `enhancement`
-- Balance workload between agents by checking open issue counts:
+- Balance workload between agents by counting only *actionable* open issues
+  (exclude issues already in the review cycle via `needs-review` or `needs:changes`):
   ```
-  gh issue list --label assigned:claude --state open --json number | jq length
-  gh issue list --label assigned:codex --state open --json number | jq length
+  gh issue list --label assigned:claude --state open --json number,labels \
+    | jq '[.[] | select(.labels | map(.name) | (contains(["needs-review"]) or contains(["needs:changes"])) | not)] | length'
+  gh issue list --label assigned:codex --state open --json number,labels \
+    | jq '[.[] | select(.labels | map(.name) | (contains(["needs-review"]) or contains(["needs:changes"])) | not)] | length'
   ```
-  Assign to whichever agent has fewer open issues (`assigned:claude` or `assigned:codex`).
+  Assign to whichever agent has fewer actionable open issues.
   Break ties by assigning to `assigned:codex`.
 - Add any other relevant labels that already exist in the repo (check with `gh label list`).
 


### PR DESCRIPTION
## Summary

- Update workload balancing in both `issue` skills (`.claude/skills/issue/SKILL.md` and `skills/issue/SKILL.md`)
- Previous logic counted all open assigned issues; in-flight issues (`needs-review`, `needs:changes`) now excluded
- Uses `jq` to filter labels before counting, so only issues actively awaiting implementation affect the assignment decision

## Testing

- Verified jq expression live: Claude actionable=2, Codex actionable=0 (issue #48, which has `needs-review`, correctly excluded from Claude's count)

Closes #54

## Summary by Sourcery

Documentation:
- Document workload balancing so only open issues not in review (`needs-review`/`needs:changes`) are counted when choosing an assignee for issue skills.