### PR TITLE
fix(skills): make unwind journal push conflict-resistant

### DIFF
--- a/skills/unwind/SKILL.md
+++ b/skills/unwind/SKILL.md
@@ -69,12 +69,29 @@ share something you found interesting, ask a question, agree or disagree>
 
 5. Commit the journal.
 
-- Stage and commit `/workspace/unwind.md`:
-  ```
-  git -C /workspace add unwind.md
-  git -C /workspace commit -m "chore: Codex unwind entry <date>"
-  git -C /workspace push
-  ```
+Because two agents may finish around the same time and both try to push
+`unwind.md`, use a pull-rebase-then-push retry loop. `unwind.md` is
+append-only so there are no semantic conflicts — git just needs to
+linearise the commits.
+
+```
+# 1. Pull any concurrent commits before writing ours
+git -C /workspace pull --rebase
+
+# 2. Stage and commit
+git -C /workspace add unwind.md
+git -C /workspace commit -m "chore: Codex unwind entry <date>"
+
+# 3. Push with up to 3 retries on rejection
+for i in 1 2 3; do
+  git -C /workspace push && break
+  echo "Push attempt $i failed — rebasing and retrying..."
+  git -C /workspace pull --rebase
+done
+```
+
+If push still fails after 3 attempts, leave the commit local and report
+the failure rather than blocking indefinitely.
 
 ## Guardrails
 


### PR DESCRIPTION
## Summary

- Replace bare `git push` with a pull-rebase-then-push retry loop in both `unwind` skills (`.claude/skills/unwind/SKILL.md` and `skills/unwind/SKILL.md`)
- Strategy: pull before committing, then retry push up to 3 times with a `git pull --rebase` between each attempt
- `unwind.md` is append-only so concurrent entries from two agents never create semantic conflicts — only linearisation is needed
- After 3 failures the commit is left local and failure is reported rather than blocking indefinitely

## Testing

- Logic-only change to skill documentation; no runtime code modified
- The retry pattern is standard shell and handles the common simultaneous-push race deterministically

Closes #55

## Summary by Sourcery

Document a conflict-resistant git workflow for updating unwind journal entries in both Claude and Codex unwind skills.

Enhancements:
- Describe a pull–rebase–then–push retry loop for committing unwind.md to handle concurrent pushes without semantic conflicts.
- Clarify that failed pushes after multiple retries should leave commits local and report failure instead of blocking indefinitely.