### PR TITLE
build-feature: verify issue base state before implementation

### DIFF
--- a/.claude/skills/build-feature/SKILL.md
+++ b/.claude/skills/build-feature/SKILL.md
@@ -43,23 +43,31 @@ The main `/workspace` checkout always stays on `main`.
   ```
 - All subsequent file reads, edits, and git commands operate inside `/workspace/.worktrees/<branch>`.
 
-4. Implement fix.
+4. Verify issue-described base state on `main`.
+
+- Before editing, confirm that the key base-state assumption in the issue body is actually true on `origin/main`.
+- Use quick checks (`rg`, targeted file reads, or `gh pr list --search`) from the issue worktree to validate the described starting point.
+- If the described state is not present on `main`:
+  - Note the mismatch in your PR summary.
+  - Adjust implementation to the real `main` state (do not assume pending/unmerged PR state).
+
+5. Implement fix.
 
 - Make the smallest safe change that satisfies acceptance criteria.
 - Update tests only when required by behavior changes.
 
-5. Verify.
+6. Verify.
 
 - Run focused tests first, then broader relevant tests (from within the worktree directory).
 - Record pass/fail summary for PR notes.
 
-6. Commit and push.
+7. Commit and push.
 
 - Stage only intended files (run git commands from the worktree path).
 - Write a specific commit message.
 - Push: `git -C /workspace/.worktrees/<branch> push -u origin <branch>`.
 
-7. Open PR.
+8. Open PR.
 
 - Write the PR body to a temp file, then create the PR:
   ```
@@ -78,11 +86,11 @@ The main `/workspace` checkout always stays on `main`.
   gh pr create --title "<title>" --body-file /tmp/gh-body.md --base main --head <branch>
   ```
 
-8. Apply review label.
+9. Apply review label.
 
 - Add `needs-review` label to the PR and to the issue.
 
-9. Clean up the worktree.
+10. Clean up the worktree.
 
 - First, return to the root workspace so the worktree is not the current directory:
   ```

--- a/skills/build-feature/SKILL.md
+++ b/skills/build-feature/SKILL.md
@@ -43,23 +43,31 @@ Prioritize correctness, minimal diffs, and explicit verification.
   - `git worktree add -b <branch> /workspace/worktrees/<branch> origin/main`
 - Run all following commands from `/workspace/worktrees/<branch>`.
 
-4. Implement fix.
+4. Verify issue-described base state on `main`.
+
+- Before editing, confirm that the key base-state assumption in the issue body is actually true on `origin/main`.
+- Use quick checks (`rg`, targeted file reads, or `gh pr list --search`) from the issue worktree to validate the described starting point.
+- If the described state is not present on `main`:
+  - Note the mismatch in your PR summary.
+  - Adjust implementation to the real `main` state (do not assume pending/unmerged PR state).
+
+5. Implement fix.
 
 - Make the smallest safe change that satisfies acceptance criteria.
 - Update tests only when required by behavior changes.
 
-5. Verify.
+6. Verify.
 
 - Run focused tests first, then broader relevant tests.
 - Record pass/fail summary for PR notes.
 
-6. Commit and push.
+7. Commit and push.
 
 - Stage only intended files.
 - Write a specific commit message.
 - Push: `git push -u origin <branch>`.
 
-7. Open PR.
+8. Open PR.
 
 - Create PR against `main` unless repo specifies another base.
 - Include summary, testing, and `Closes #<number>`.
@@ -67,12 +75,12 @@ Prioritize correctness, minimal diffs, and explicit verification.
   - Write PR body to `/tmp/pr-<number>.md`.
   - Create PR with `gh pr create --base main --head <branch> --title "<title>" --body-file /tmp/pr-<number>.md`.
 
-8. Apply review label.
+9. Apply review label.
 
 - Add `needs-review` label to PR.
 - If workflow expects issue labeling too, add `needs-review` to the issue.
 
-9. Continue queue processing.
+10. Continue queue processing.
 
 - After finishing the PR handoff, call `build-feature` again to pick up the next `assigned:codex` issue.
 - Remove the issue worktree after handoff if it is clean:


### PR DESCRIPTION
## Summary

- Updated `skills/build-feature/SKILL.md` to require an explicit base-state verification step before implementation
- Updated `.claude/skills/build-feature/SKILL.md` with the same requirement
- Added guidance for handling mismatches when issue assumptions are not present on `origin/main`

## Testing

- Documentation/workflow change only

Closes #61

## Summary by Sourcery

Clarify the build-feature workflow to include verifying the issue’s described base state on main before implementation and handling mismatches accordingly.

Documentation:
- Update build-feature skill documentation to require verifying the issue-described base state on origin/main before making changes.
- Document how to record and adapt when the issue’s assumed base state does not match the actual main branch state, and renumber the workflow steps accordingly in both internal and public SKILL guides.