### PR TITLE
fix(HistoricalChart): preserve y-axis readability when forecast CI is wide

### DIFF
--- a/frontend/src/__tests__/HistoricalChart.test.jsx
+++ b/frontend/src/__tests__/HistoricalChart.test.jsx
@@ -1,0 +1,44 @@
+import { render } from '@testing-library/react'
+import HistoricalChart from '../components/HistoricalChart'
+
+const historicalData = [
+  { season: '2023/2024', week_offset: 10, cases: 80 },
+  { season: '2023/2024', week_offset: 15, cases: 100 },
+  { season: '2023/2024', week_offset: 20, cases: 70 },
+]
+
+// Forecast where CI upper is far above historical data (100x the mean)
+const wideCIForecast = {
+  forecast: [
+    { date: '2024-01-07', forecast: 90, lower: 50, upper: 10000 },
+    { date: '2024-01-14', forecast: 85, lower: 45, upper: 9500 },
+  ],
+}
+
+describe('HistoricalChart', () => {
+  it('renders the svg without crashing', () => {
+    const { container } = render(<HistoricalChart data={historicalData} />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('does not expand y-axis to forecast CI upper bound when CI is wide', () => {
+    const { container } = render(
+      <HistoricalChart data={historicalData} forecast={wideCIForecast} />,
+    )
+    const tickTexts = Array.from(
+      container.querySelectorAll('svg text'),
+    ).map(el => el.textContent)
+
+    // d3.format('.2s') renders 1000+ as e.g. "1.00k", "10.0k"
+    // If y-axis max were driven by CI upper (~10000), ticks would contain 'k'
+    const hasKiloTick = tickTexts.some(t => t.includes('k') || t.includes('K'))
+    expect(hasKiloTick).toBe(false)
+  })
+
+  it('adds a clipPath element when forecast is provided', () => {
+    const { container } = render(
+      <HistoricalChart data={historicalData} forecast={wideCIForecast} />,
+    )
+    expect(container.querySelector('clipPath')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- `yMax` now uses `d3.max(fcastPoints, d => d.forecast)` (forecast mean) instead of `d3.max(fcastPoints, d => d.upper)` (CI upper bound)
- Added SVG `<clipPath id="chart-area-clip">` that bounds the CI area band to the chart margins — CI band still renders and is visible, but wide uncertainty intervals no longer expand the y-domain
- Added `frontend/src/__tests__/HistoricalChart.test.jsx` with 3 tests:
  - Renders SVG without crashing
  - With CI upper 100× larger than historical max, y-axis ticks contain no "k"-scale values (verifies yMax is not driven by CI upper)
  - `<clipPath>` element is present when forecast is provided

## Testing

- `npm test` → 19/19 tests pass (5 new test file, 3 new tests)

Closes #63

## Summary by Sourcery

Adjust HistoricalChart y-axis scaling and forecast rendering to keep historical data readable when forecast confidence intervals are very wide.

New Features:
- Add clipping of the forecast confidence interval band to the chart drawing area to prevent it from extending outside the plot.

Bug Fixes:
- Base the chart y-axis maximum on observed data and forecast mean instead of the forecast confidence interval upper bound to avoid compressing historical series when uncertainty is large.

Tests:
- Add HistoricalChart tests to verify SVG renders, y-axis is not driven by extreme CI upper bounds, and the forecast clipPath element is present.