### PR TITLE
ci: add 3-job workflow for frontend, backend, and e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Run E2E tests
         working-directory: frontend
-        run: npx playwright test
+        run: npx playwright test --pass-with-no-tests
 
       - name: Upload Playwright report on failure
         if: failure()


### PR DESCRIPTION
## Summary

- replace the existing lint-only `ci.yml` with a 3-job test pipeline:
  - `frontend-unit-tests` (`npm ci`, `npm test`)
  - `backend-tests` (`pip install -r requirements.txt`, `pytest` with SQLite in-memory `DATABASE_URL`)
  - `e2e-tests` (docker compose stack, health check, Playwright install + test, report upload on failure)
- wire `e2e-tests` to run only after both unit-test jobs pass
- keep triggers on all pull requests and pushes to `main`

## Main-state note

- On current `origin/main` (February 18, 2026), dedicated Playwright specs are not yet present, so the E2E step uses `--pass-with-no-tests` to keep the workflow green until the E2E test issue lands.

## Testing

- `cd frontend && npm ci && npm test`
- `cd backend && DATABASE_URL='sqlite+aiosqlite:///file:test?mode=memory&cache=shared&uri=true' pytest`

Closes #77

## Summary by Sourcery

Introduce a multi-job CI pipeline that runs frontend, backend, and end-to-end tests on pushes to main and all pull requests.

CI:
- Replace the previous frontend lint-only workflow with a three-job pipeline for frontend unit tests, backend tests, and E2E tests.
- Configure E2E tests to run after both frontend and backend jobs complete, spinning up the full stack via Docker Compose and collecting Playwright reports on failure.