### PR TITLE
feat: add clipped-CI indicator to HistoricalChart

### DIFF
--- a/frontend/src/__tests__/HistoricalChart.test.jsx
+++ b/frontend/src/__tests__/HistoricalChart.test.jsx
@@ -14,6 +14,12 @@ const wideCIForecast = {
     { date: '2024-01-14', forecast: 85, lower: 45, upper: 9500 },
   ],
 }
+const boundedForecast = {
+  forecast: [
+    { date: '2024-01-07', forecast: 90, lower: 50, upper: 95 },
+    { date: '2024-01-14', forecast: 85, lower: 45, upper: 92 },
+  ],
+}
 
 describe('HistoricalChart', () => {
   it('renders the svg without crashing', () => {
@@ -40,5 +46,20 @@ describe('HistoricalChart', () => {
       <HistoricalChart data={historicalData} forecast={wideCIForecast} />,
     )
     expect(container.querySelector('clipPath')).toBeInTheDocument()
+  })
+
+  it('shows CI clipping indicator when forecast upper bound exceeds y-axis domain', () => {
+    const { container } = render(
+      <HistoricalChart data={historicalData} forecast={wideCIForecast} />,
+    )
+    expect(container.querySelector('svg text')?.textContent).toBeTruthy()
+    expect(container.textContent).toContain('↑ CI extends beyond chart')
+  })
+
+  it('does not show CI clipping indicator when forecast upper bound fits in domain', () => {
+    const { container } = render(
+      <HistoricalChart data={historicalData} forecast={boundedForecast} />,
+    )
+    expect(container.textContent).not.toContain('↑ CI extends beyond chart')
   })
 })

--- a/frontend/src/components/HistoricalChart.jsx
+++ b/frontend/src/components/HistoricalChart.jsx
@@ -49,6 +49,8 @@ export default function HistoricalChart({ data, country = '', forecast = null, f
       d3.max(data, d => d.cases) || 1,
       d3.max(fcastPoints, d => d.forecast) || 0,
     )
+    const ciUpperMax = d3.max(fcastPoints, d => d.upper) || 0
+    const isCiClipped = ciUpperMax > yMax
 
     const x = d3.scaleLinear().domain(xExtent).range([margin.left, width - margin.right])
     const y = d3.scaleLinear().domain([0, yMax]).range([height - margin.bottom, margin.top])
@@ -145,6 +147,25 @@ export default function HistoricalChart({ data, country = '', forecast = null, f
           .attr('fill', '#f59e0b')
           .attr('font-size', '0.65rem')
           .text('Forecast')
+
+        if (isCiClipped) {
+          svg.append('line')
+            .attr('x1', margin.left)
+            .attr('x2', width - margin.right)
+            .attr('y1', margin.top + 1)
+            .attr('y2', margin.top + 1)
+            .attr('stroke', '#f59e0b')
+            .attr('stroke-width', 1)
+            .attr('stroke-dasharray', '3,3')
+            .attr('opacity', 0.8)
+
+          svg.append('text')
+            .attr('x', margin.left + 4)
+            .attr('y', margin.top + 12)
+            .attr('fill', '#f59e0b')
+            .attr('font-size', '0.65rem')
+            .text('↑ CI extends beyond chart')
+        }
       }
     }
   }, [data, forecast])


### PR DESCRIPTION
## Summary

- add a visual clip indicator in `HistoricalChart` when forecast CI upper values exceed the chart y-domain
- render a dashed top boundary marker plus `↑ CI extends beyond chart` annotation only when clipping is active
- extend `HistoricalChart` tests to assert indicator visibility for clipped CI and absence for bounded CI

## Testing

- `npm test -- --run src/__tests__/HistoricalChart.test.jsx`
- `npm test`

Closes #67

## Summary by Sourcery

Add a visual indicator to HistoricalChart when forecast confidence intervals are clipped by the chart domain.

New Features:
- Display a dashed upper boundary line and text annotation when forecast CI upper bounds exceed the chart y-axis domain.

Tests:
- Extend HistoricalChart tests to cover presence and absence of the CI clipping indicator for clipped vs bounded forecasts.