### PR TITLE
feat: add CI clip indicator to HistoricalChart when CI band is clipped

### DIFF
--- a/frontend/src/__tests__/HistoricalChart.test.jsx
+++ b/frontend/src/__tests__/HistoricalChart.test.jsx
@@ -41,4 +41,26 @@ describe('HistoricalChart', () => {
     )
     expect(container.querySelector('clipPath')).toBeInTheDocument()
   })
+
+  it('renders the CI clip indicator when CI upper bound exceeds yMax', () => {
+    const { container } = render(
+      <HistoricalChart data={historicalData} forecast={wideCIForecast} />,
+    )
+    // wideCIForecast has upper=10000 which far exceeds yMax (~100)
+    expect(container.querySelector('.ci-clip-indicator')).toBeInTheDocument()
+  })
+
+  it('does not render the CI clip indicator when CI fits within the domain', () => {
+    const fittingCIForecast = {
+      forecast: [
+        { date: '2024-01-07', forecast: 90, lower: 50, upper: 95 },
+        { date: '2024-01-14', forecast: 85, lower: 45, upper: 95 },
+      ],
+    }
+    const { container } = render(
+      <HistoricalChart data={historicalData} forecast={fittingCIForecast} />,
+    )
+    // upper=95 < yMax=100, so no clipping indicator
+    expect(container.querySelector('.ci-clip-indicator')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/HistoricalChart.jsx
+++ b/frontend/src/components/HistoricalChart.jsx
@@ -49,6 +49,8 @@ export default function HistoricalChart({ data, country = '', forecast = null, f
       d3.max(data, d => d.cases) || 1,
       d3.max(fcastPoints, d => d.forecast) || 0,
     )
+    const ciUpperMax = d3.max(fcastPoints, d => d.upper) || 0
+    const ciIsClipped = fcastPoints.length > 0 && ciUpperMax > yMax
 
     const x = d3.scaleLinear().domain(xExtent).range([margin.left, width - margin.right])
     const y = d3.scaleLinear().domain([0, yMax]).range([height - margin.bottom, margin.top])
@@ -146,6 +148,29 @@ export default function HistoricalChart({ data, country = '', forecast = null, f
           .attr('font-size', '0.65rem')
           .text('Forecast')
       }
+    }
+
+    // Visual indicator when CI band is clipped at the top of the chart area
+    if (ciIsClipped) {
+      svg.append('line')
+        .attr('class', 'ci-clip-indicator')
+        .attr('x1', margin.left)
+        .attr('x2', width - margin.right)
+        .attr('y1', margin.top)
+        .attr('y2', margin.top)
+        .attr('stroke', '#f59e0b')
+        .attr('stroke-width', 1.5)
+        .attr('stroke-dasharray', '4,4')
+        .attr('opacity', 0.9)
+
+      svg.append('text')
+        .attr('class', 'ci-clip-indicator')
+        .attr('x', width - margin.right - 4)
+        .attr('y', margin.top + 10)
+        .attr('fill', '#f59e0b')
+        .attr('font-size', '0.6rem')
+        .attr('text-anchor', 'end')
+        .text('\u2191 CI extends beyond chart')
     }
   }, [data, forecast])
 


### PR DESCRIPTION
## Summary

- Adds a visual indicator (dashed amber horizontal line + "↑ CI extends beyond chart" text) at the top of the chart area when the forecast confidence interval's upper bound exceeds the y-axis maximum (`ciUpperMax > yMax`)
- The indicator is only rendered when clipping is actually occurring
- Uses the existing forecast amber color (`#f59e0b`) for visual consistency
- Indicator is positioned at the chart boundary and anchored to the right, avoiding obstruction of chart data and axis labels

## Testing

- `vitest run` — 39 tests pass (5 in HistoricalChart suite, including 2 new tests)
- New test: `renders the CI clip indicator when CI upper bound exceeds yMax` — passes with wideCIForecast (upper=10000 >> yMax=100)
- New test: `does not render the CI clip indicator when CI fits within the domain` — passes with fittingCIForecast (upper=95 < yMax=100)

Closes #67

## Summary by Sourcery

Indicate when the forecast confidence interval is clipped at the top of the HistoricalChart.

New Features:
- Display a visual CI clipping indicator in HistoricalChart when the forecast confidence interval upper bound exceeds the chart y-axis maximum.

Tests:
- Add tests verifying that the CI clipping indicator appears when the upper bound exceeds yMax and is absent when the CI fits within the chart domain.