### PR TITLE
test: add integration tests for Dashboard and Genomics pages

### DIFF
--- a/frontend/src/__tests__/Dashboard.test.jsx
+++ b/frontend/src/__tests__/Dashboard.test.jsx
@@ -1,0 +1,130 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+vi.mock('../api', () => ({
+  api: {
+    summary: vi.fn(),
+    mapData: vi.fn(),
+    historical: vi.fn(),
+    forecast: vi.fn(),
+    subtypes: vi.fn(),
+    countries: vi.fn(),
+    anomalies: vi.fn(),
+    genomicTrends: vi.fn(),
+  },
+}))
+
+vi.mock('../components/ChoroplethMap', () => ({
+  default: ({ onSelectCountry }) => (
+    <button onClick={() => onSelectCountry('US')}>MockMap</button>
+  ),
+}))
+
+vi.mock('../components/HistoricalChart', () => ({
+  default: () => <div>MockHistoricalChart</div>,
+}))
+
+vi.mock('../components/CladeTrends', () => ({
+  default: () => <div>MockCladeTrends</div>,
+}))
+
+vi.mock('../components/SubtypeTrends', () => ({
+  default: () => <div>MockSubtypeTrends</div>,
+}))
+
+import { api } from '../api'
+import Dashboard from '../pages/Dashboard'
+
+const summaryData = {
+  total_cases: 100000,
+  countries_reporting: 42,
+  current_week_cases: 1200,
+  week_change_pct: 3.5,
+}
+
+const countriesData = [
+  {
+    country_code: 'US',
+    total_cases: 5000,
+    per_100k: 15.2,
+    delta_pct: 3.5,
+    severity: 0.8,
+    dominant_type: 'H3N2',
+    sparkline: [1, 2, 3],
+  },
+]
+
+function renderDashboard() {
+  return render(
+    <MemoryRouter>
+      <Dashboard />
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  api.summary.mockResolvedValue(summaryData)
+  api.mapData.mockResolvedValue([])
+  api.historical.mockResolvedValue([])
+  api.forecast.mockResolvedValue([])
+  api.subtypes.mockResolvedValue([])
+  api.countries.mockResolvedValue(countriesData)
+  api.anomalies.mockResolvedValue([])
+  api.genomicTrends.mockResolvedValue([])
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('Dashboard', () => {
+  it('happy path — KPI labels visible, AlertBar present, CountryTable header present', async () => {
+    renderDashboard()
+
+    await waitFor(() => expect(screen.getByText('Total Cases')).toBeInTheDocument())
+    expect(screen.getByText('Countries Reporting')).toBeInTheDocument()
+    expect(screen.getByText('This Week')).toBeInTheDocument()
+    expect(screen.getByText('Week Change')).toBeInTheDocument()
+
+    expect(screen.getByText('No active anomalies')).toBeInTheDocument()
+
+    await waitFor(() => expect(screen.getByText('Country Dashboard')).toBeInTheDocument())
+  })
+
+  it('summaryError — error message visible, KPI section absent', async () => {
+    api.summary.mockRejectedValue(new Error('summary failed'))
+    renderDashboard()
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Failed to load summary data — please refresh.'),
+      ).toBeInTheDocument(),
+    )
+    expect(screen.queryByText('Total Cases')).not.toBeInTheDocument()
+  })
+
+  it('anomaliesError — AlertBar shows error message', async () => {
+    api.anomalies.mockRejectedValue(new Error('anomalies failed'))
+    renderDashboard()
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Unable to load anomaly alerts — please refresh.'),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('country selection — api.historical and api.forecast called with country=US', async () => {
+    renderDashboard()
+
+    await waitFor(() => expect(api.historical).toHaveBeenCalledWith(''))
+
+    fireEvent.click(screen.getByText('MockMap'))
+
+    await waitFor(() =>
+      expect(api.historical).toHaveBeenCalledWith('country=US'),
+    )
+    expect(api.forecast).toHaveBeenCalledWith('country=US')
+  })
+})

--- a/frontend/src/__tests__/Genomics.test.jsx
+++ b/frontend/src/__tests__/Genomics.test.jsx
@@ -1,0 +1,130 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+vi.mock('../api', () => ({
+  api: {
+    genomicTrends: vi.fn(),
+    genomicSummary: vi.fn(),
+    genomicCountries: vi.fn(),
+  },
+}))
+
+vi.mock('../components/CladeTrends', () => ({
+  default: () => <div>MockCladeTrends</div>,
+}))
+
+import { api } from '../api'
+import Genomics from '../pages/Genomics'
+
+const summaryData = {
+  total_sequences: 12345,
+  countries: 12,
+  unique_clades: 9,
+  dominant_clade: '3C.2a1b',
+}
+
+const countriesData = [
+  { country_code: 'US', total_sequences: 1500, top_clade: '3C.2a1b' },
+  { country_code: 'GB', total_sequences: 900, top_clade: '3C.2a1b.2a.1' },
+]
+
+function renderGenomics() {
+  return render(
+    <MemoryRouter>
+      <Genomics />
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  api.genomicTrends.mockResolvedValue([])
+  api.genomicSummary.mockResolvedValue(summaryData)
+  api.genomicCountries.mockResolvedValue(countriesData)
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('Genomics', () => {
+  it('happy path — heading, KPI values, GenomicsTable rows visible', async () => {
+    renderGenomics()
+
+    expect(screen.getByText('Genomics Dashboard')).toBeInTheDocument()
+
+    await waitFor(() => expect(screen.getByText('Total Sequences')).toBeInTheDocument())
+    expect(screen.getByText('Countries')).toBeInTheDocument()
+    expect(screen.getByText('Unique Clades')).toBeInTheDocument()
+    expect(screen.getByText('Dominant Clade')).toBeInTheDocument()
+
+    await waitFor(() => expect(screen.getAllByText('US').length).toBeGreaterThan(0))
+    expect(screen.getAllByText('GB').length).toBeGreaterThan(0)
+  })
+
+  it('"3yr" button click — api.genomicTrends called with years=3', async () => {
+    renderGenomics()
+
+    fireEvent.click(screen.getByText('3yr'))
+
+    await waitFor(() =>
+      expect(api.genomicTrends).toHaveBeenCalledWith(
+        expect.stringContaining('years=3'),
+      ),
+    )
+  })
+
+  it('"Top 4" button click — api.genomicTrends called with top_n=4', async () => {
+    renderGenomics()
+
+    fireEvent.click(screen.getByText('Top 4'))
+
+    await waitFor(() =>
+      expect(api.genomicTrends).toHaveBeenCalledWith(
+        expect.stringContaining('top_n=4'),
+      ),
+    )
+  })
+
+  it('country select — api.genomicTrends called with country=US param', async () => {
+    renderGenomics()
+
+    await waitFor(() =>
+      expect(screen.getByRole('combobox')).toBeInTheDocument(),
+    )
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'US' } })
+
+    await waitFor(() =>
+      expect(api.genomicTrends).toHaveBeenCalledWith(
+        expect.stringContaining('country=US'),
+      ),
+    )
+  })
+
+  it('trendsError — error message shown, CladeTrends chart absent', async () => {
+    api.genomicTrends.mockRejectedValue(new Error('trends failed'))
+    renderGenomics()
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Failed to load trend data — please refresh.'),
+      ).toBeInTheDocument(),
+    )
+    expect(screen.queryByText('MockCladeTrends')).not.toBeInTheDocument()
+  })
+
+  it('ArrowRight keyboard nav on year radio group cycles to next year', async () => {
+    renderGenomics()
+
+    const btn1yr = screen.getByText('1yr')
+    expect(btn1yr).toHaveAttribute('aria-checked', 'true')
+
+    fireEvent.keyDown(btn1yr, { key: 'ArrowRight' })
+
+    await waitFor(() =>
+      expect(screen.getByText('3yr')).toHaveAttribute('aria-checked', 'true'),
+    )
+    expect(screen.getByText('1yr')).toHaveAttribute('aria-checked', 'false')
+  })
+})


### PR DESCRIPTION
## Summary

- Add `Dashboard.test.jsx`: 4 integration tests covering happy path (KPI labels, AlertBar, CountryTable), `summaryError`, `anomaliesError`, and country selection via mocked `ChoroplethMap`
- Add `Genomics.test.jsx`: 6 integration tests covering happy path (heading, KPI values, GenomicsTable rows), year button click, Top N button click, country select, `trendsError`, and ArrowRight keyboard nav on year radio group
- Mock `../api` module with `vi.mock` to control all API calls
- Mock `ChoroplethMap` at module level to avoid CDN fetch; mock also exposes `onSelectCountry` for country-selection testing
- Wrap both pages in `MemoryRouter` for `react-router-dom` `Link` compatibility
- No new dependencies required

## Testing

- `vitest run src/__tests__/Dashboard.test.jsx src/__tests__/Genomics.test.jsx` — 10/10 pass
- `vitest run` (full suite) — 49/49 pass

Closes #74

## Summary by Sourcery

Add integration test coverage for the Dashboard and Genomics pages using mocked API and UI components.

Tests:
- Add integration tests for the Dashboard page covering happy path rendering, error states, and country-selection behavior.
- Add integration tests for the Genomics page covering happy path rendering, filter interactions, error handling, and keyboard navigation on the year selector.