### PR TITLE
test: add Playwright E2E tests for critical user flows

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "flutracker-e2e",
+  "version": "1.0.0",
+  "description": "Playwright E2E tests for FluTracker",
+  "scripts": {
+    "test": "playwright test",
+    "test:report": "playwright test --reporter=html"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.41.0"
+  }
+}

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -1,0 +1,23 @@
+// @ts-check
+const { defineConfig, devices } = require('@playwright/test')
+
+module.exports = defineConfig({
+  testDir: './tests',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost',
+    headless: true,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/e2e/tests/dashboard.spec.js
+++ b/e2e/tests/dashboard.spec.js
@@ -1,0 +1,77 @@
+// @ts-check
+const { test, expect } = require('@playwright/test')
+
+const TIMEOUT = 10_000
+
+test.describe('Dashboard', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+  })
+
+  test('4 KPI cards are visible', async ({ page }) => {
+    await expect(page.getByText('Total Cases')).toBeVisible({ timeout: TIMEOUT })
+    await expect(page.getByText('Countries Reporting')).toBeVisible({ timeout: TIMEOUT })
+    await expect(page.getByText('This Week')).toBeVisible({ timeout: TIMEOUT })
+    await expect(page.getByText('Week Change')).toBeVisible({ timeout: TIMEOUT })
+  })
+
+  test('AlertBar container is present', async ({ page }) => {
+    // AlertBar always renders below the page header in one of three states:
+    // "No active anomalies", a load-error message, or anomaly chips.
+    // Wait for the KPI section to confirm the page settled.
+    await expect(page.getByText('Total Cases')).toBeVisible({ timeout: TIMEOUT })
+
+    // Assert that none of AlertBar's states triggered an ErrorBoundary crash.
+    await expect(
+      page.getByText('Something went wrong loading this section.'),
+    ).not.toBeVisible()
+
+    // One of the known text states must be visible, or anomaly chips exist.
+    const emptyState = page.getByText('No active anomalies')
+    const errorState = page.getByText('Unable to load anomaly alerts — please refresh.')
+    const chipState = page.locator('[style*="rgba(239, 68, 68, 0.15)"]').first()
+
+    const found = await Promise.any([
+      emptyState.waitFor({ state: 'visible', timeout: TIMEOUT }),
+      errorState.waitFor({ state: 'visible', timeout: TIMEOUT }),
+      chipState.waitFor({ state: 'visible', timeout: TIMEOUT }),
+    ]).then(() => true).catch(() => false)
+
+    expect(found, 'AlertBar should render in one of its known states').toBe(true)
+  })
+
+  test('Country table has at least one data row', async ({ page }) => {
+    await expect(page.getByText('Country Dashboard')).toBeVisible({ timeout: TIMEOUT })
+
+    const rows = page.locator('table tbody tr')
+    await expect(rows.first()).toBeVisible({ timeout: TIMEOUT })
+
+    const count = await rows.count()
+    expect(count).toBeGreaterThan(0)
+  })
+
+  test('Clicking a table row highlights it and chart SVG remains present', async ({ page }) => {
+    await expect(page.getByText('Country Dashboard')).toBeVisible({ timeout: TIMEOUT })
+
+    const firstRow = page.locator('table tbody tr').first()
+    await firstRow.waitFor({ timeout: TIMEOUT })
+    await firstRow.click()
+
+    // Row receives a highlighted background (amber tint applied via inline style)
+    await expect(firstRow).toHaveCSS('background-color', /^rgba\(245, 158, 11/)
+
+    // Chart SVG is still present (HistoricalChart or ChoroplethMap)
+    await expect(page.locator('svg').first()).toBeVisible({ timeout: TIMEOUT })
+  })
+
+  test('Navigate to Genomics via "View Genomics Dashboard" link', async ({ page }) => {
+    await expect(
+      page.getByRole('link', { name: /View Genomics Dashboard/i }),
+    ).toBeVisible({ timeout: TIMEOUT })
+
+    await page.getByRole('link', { name: /View Genomics Dashboard/i }).click()
+
+    await expect(page).toHaveURL('/genomics', { timeout: TIMEOUT })
+    await expect(page.getByText('Genomics Dashboard')).toBeVisible({ timeout: TIMEOUT })
+  })
+})

--- a/e2e/tests/genomics.spec.js
+++ b/e2e/tests/genomics.spec.js
@@ -1,0 +1,24 @@
+// @ts-check
+const { test, expect } = require('@playwright/test')
+
+const TIMEOUT = 10_000
+
+test.describe('Genomics', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/genomics')
+    await expect(page.getByText('Genomics Dashboard')).toBeVisible({ timeout: TIMEOUT })
+  })
+
+  test('"3yr" button click sets aria-checked="true" on that button', async ({ page }) => {
+    const btn3yr = page.getByRole('radio', { name: '3yr' })
+    await expect(btn3yr).toBeVisible({ timeout: TIMEOUT })
+
+    // Initially 1yr is selected
+    await expect(page.getByRole('radio', { name: '1yr' })).toHaveAttribute('aria-checked', 'true')
+
+    await btn3yr.click()
+
+    await expect(btn3yr).toHaveAttribute('aria-checked', 'true', { timeout: TIMEOUT })
+    await expect(page.getByRole('radio', { name: '1yr' })).toHaveAttribute('aria-checked', 'false')
+  })
+})


### PR DESCRIPTION
## Summary

- New `e2e/` directory at repo root with `@playwright/test` and `playwright.config.js` (baseURL `http://localhost`, headless Chromium, 1 worker)
- `dashboard.spec.js` — 5 scenarios:
  1. 4 KPI cards ("Total Cases", "Countries Reporting", "This Week", "Week Change") visible after page load
  2. AlertBar container present in any of its three possible states (empty, load-error, or chips)
  3. Country table has at least one data row
  4. Clicking a table row highlights it with an amber background and the chart SVG remains visible
  5. Navigating to Genomics via "View Genomics Dashboard →" link lands on `/genomics` with heading visible
- `genomics.spec.js` — 1 scenario:
  6. "3yr" button click sets `aria-checked="true"` on that button and clears it on "1yr"
- Uses stable selectors: `getByText`, `getByRole`, `locator('table tbody tr')` — no class or id coupling
- 10 s `timeout` on async waits for live-backend data loads

## Testing

```bash
docker compose up -d
cd e2e && npx playwright install chromium && npx playwright test
```

Closes #76

## Summary by Sourcery

Add a Playwright-based end-to-end test suite covering critical dashboard and genomics user flows.

Build:
- Introduce standalone e2e package with Playwright config, Chromium project, and npm scripts for running tests and HTML reports.

Tests:
- Add Playwright E2E tests for key dashboard KPIs, alert bar states, country table behavior, row selection highlighting, and navigation to the genomics dashboard.
- Add a genomics dashboard E2E test validating the 1-year vs 3-year range toggle via aria-checked states.