### PR TITLE
ci: remove --pass-with-no-tests guard from Playwright E2E step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Run E2E tests
         working-directory: frontend
-        run: npx playwright test --pass-with-no-tests
+        run: npx playwright test
 
       - name: Upload Playwright report on failure
         if: failure()


### PR DESCRIPTION
## Summary

- Removed `--pass-with-no-tests` flag from the Playwright E2E step in `.github/workflows/ci.yml`
- CI will now fail when Playwright discovers zero tests, preventing silent regressions from path drift or misconfiguration

## Testing

- Existing E2E tests in `frontend/e2e/` (added in #87) provide test coverage and will ensure the step still passes on valid runs
- The flag removal means any future test-discovery failure will surface as a CI failure rather than a silent pass

Closes #89

## Summary by Sourcery

CI:
- Remove the --pass-with-no-tests flag from the Playwright E2E step so CI fails when no E2E tests are discovered.