### PR TITLE
fix: handle no-required-checks case in review skill

### DIFF
--- a/.claude/skills/review-peer-prs/SKILL.md
+++ b/.claude/skills/review-peer-prs/SKILL.md
@@ -43,7 +43,14 @@ Find GitHub issues ready for review in the peer agent queue, locate the associat
 
 - Read PR details: `gh pr view <pr-number>`.
 - Read full diff: `gh pr diff <pr-number>`.
-- Check CI status: `gh pr checks <pr-number> --required`.
+- Check required CI status with explicit no-required handling:
+  - `set +e`
+  - `checks_output="$(gh pr checks <pr-number> --required 2>&1)"`
+  - `checks_code=$?`
+  - `set -e`
+  - If `checks_code` is `0`, required checks are green.
+  - If `checks_code` is non-zero and `checks_output` contains `no required checks reported`, treat as green and continue.
+  - Otherwise, treat as failing checks and request changes.
 - If local validation is needed, use a temporary review worktree:
   - `git fetch origin <headRefName>`
   - `git worktree add /workspace/worktrees/review-pr-<pr-number> origin/<headRefName>`
@@ -95,6 +102,7 @@ Use this structure:
 
 - Do NOT use `gh pr review --approve` (fails on own PRs). Use `gh pr comment` instead.
 - Do not merge if required checks are failing.
+- Treat `gh pr checks --required` exit `1` with `no required checks reported` as a passing no-required-checks state.
 - Provide specific, actionable feedback when requesting changes.
 - Review the full diff, not only summary text.
 - Prefer temporary worktrees for local PR validation.

--- a/skills/review-peer-prs/SKILL.md
+++ b/skills/review-peer-prs/SKILL.md
@@ -43,7 +43,14 @@ Find GitHub issues ready for review in the peer agent queue, locate the associat
 
 - Read PR details: `gh pr view <pr-number>`.
 - Read full diff: `gh pr diff <pr-number>`.
-- Check CI status: `gh pr checks <pr-number> --required`.
+- Check required CI status with explicit no-required handling:
+  - `set +e`
+  - `checks_output="$(gh pr checks <pr-number> --required 2>&1)"`
+  - `checks_code=$?`
+  - `set -e`
+  - If `checks_code` is `0`, required checks are green.
+  - If `checks_code` is non-zero and `checks_output` contains `no required checks reported`, treat as green and continue.
+  - Otherwise, treat as failing checks and request changes.
 - If local validation is needed, use a temporary review worktree:
   - `git fetch origin <headRefName>`
   - `git worktree add /workspace/worktrees/review-pr-<pr-number> origin/<headRefName>`
@@ -95,6 +102,7 @@ Use this structure:
 
 - Do NOT use `gh pr review --approve` (fails on own PRs). Use `gh pr comment` instead.
 - Do not merge if required checks are failing.
+- Treat `gh pr checks --required` exit `1` with `no required checks reported` as a passing no-required-checks state.
 - Provide specific, actionable feedback when requesting changes.
 - Review the full diff, not only summary text.
 - Prefer temporary worktrees for local PR validation.


### PR DESCRIPTION
## Summary

- update `skills/review-peer-prs/SKILL.md` to handle `gh pr checks --required` exit code `1` when GitHub reports no required checks
- mirror the same fix in `.claude/skills/review-peer-prs/SKILL.md` to keep both skill copies aligned
- document that only real required-check failures should block merge decisions

## Testing

- `gh pr checks 93 --required` (observed exit `1` + "no required checks reported" on main; behavior this change now treats as green)
- `git diff -- skills/review-peer-prs/SKILL.md .claude/skills/review-peer-prs/SKILL.md` (confirmed both copies updated identically)

Closes #95

## Summary by Sourcery

Documentation:
- Update both copies of the review-peer-prs skill documentation to explicitly handle the `gh pr checks --required` no-required-checks case as a passing state and to distinguish it from real required-check failures.