### PR TITLE
fix: add --limit 200 to find-pr-for-issue.sh PR body-search

### DIFF
--- a/scripts/find-pr-for-issue.sh
+++ b/scripts/find-pr-for-issue.sh
@@ -36,7 +36,7 @@ fi
 
 # --- Strategy 2: PR body search -------------------------------------------
 # Search both open and closed PRs for "Closes #N" / "Fixes #N" in the body.
-PR=$(gh pr list --state all --json number,body \
+PR=$(gh pr list --state all --limit 200 --json number,body \
   --jq "[.[] | select(.body | test(\"(Closes|Fixes|closes|fixes) #${ISSUE}(\\\\b|$)\"))
              | .number] | first // empty" 2>/dev/null || true)
 


### PR DESCRIPTION
## Summary

- Added `--limit 200` to the `gh pr list --state all` call in Strategy 2 of `scripts/find-pr-for-issue.sh`
- The default limit is 30; any PR older than the 30 most recent would be silently missed by the body-search fallback
- Strategy 1 (timeline API with `--paginate`) is unaffected — only Strategy 2 needed this fix

## Testing

- `bash scripts/find-pr-for-issue.sh 74` → returns `86` (closed PR found via body search, validates Strategy 2 still works)
- `bash scripts/find-pr-for-issue.sh 98` → exits 1 with "No PR found" (correct — no PR exists for #98 yet)

Closes #98

## Summary by Sourcery

Bug Fixes:
- Prevent the issue-to-PR lookup script from silently missing older pull requests by raising the `gh pr list` result limit in the body-search strategy.