### PR TITLE
frontend: add stable AlertBar container selector for tests

### DIFF
--- a/frontend/src/__tests__/Dashboard.test.jsx
+++ b/frontend/src/__tests__/Dashboard.test.jsx
@@ -87,6 +87,7 @@ describe('Dashboard', () => {
     expect(screen.getByText('This Week')).toBeInTheDocument()
     expect(screen.getByText('Week Change')).toBeInTheDocument()
 
+    expect(screen.getByRole('region', { name: 'Anomaly alerts' })).toBeInTheDocument()
     expect(screen.getByText('No active anomalies')).toBeInTheDocument()
 
     await waitFor(() => expect(screen.getByText('Country Dashboard')).toBeInTheDocument())
@@ -108,6 +109,11 @@ describe('Dashboard', () => {
     api.anomalies.mockRejectedValue(new Error('anomalies failed'))
     renderDashboard()
 
+    await waitFor(() =>
+      expect(
+        screen.getByRole('region', { name: 'Anomaly alerts' }),
+      ).toBeInTheDocument(),
+    )
     await waitFor(() =>
       expect(
         screen.getByText('Unable to load anomaly alerts — please refresh.'),

--- a/frontend/src/__tests__/PureComponents.test.jsx
+++ b/frontend/src/__tests__/PureComponents.test.jsx
@@ -11,11 +11,13 @@ import { severityColor } from '../utils/colors'
 describe('AlertBar', () => {
   it('renders empty state when anomalies list is empty', () => {
     render(<AlertBar anomalies={[]} />)
+    expect(screen.getByRole('region', { name: 'Anomaly alerts' })).toBeInTheDocument()
     expect(screen.getByText('No active anomalies')).toBeInTheDocument()
   })
 
   it('renders load error state', () => {
     render(<AlertBar anomalies={[]} loadError />)
+    expect(screen.getByRole('region', { name: 'Anomaly alerts' })).toBeInTheDocument()
     expect(screen.getByText('Unable to load anomaly alerts — please refresh.')).toBeInTheDocument()
   })
 

--- a/frontend/src/components/AlertBar.jsx
+++ b/frontend/src/components/AlertBar.jsx
@@ -45,7 +45,7 @@ function severityLabel(severity) {
 export default function AlertBar({ anomalies, loadError }) {
   if (loadError) {
     return (
-      <div style={styles.bar}>
+      <div style={styles.bar} role="region" aria-label="Anomaly alerts">
         <span style={{ ...styles.empty, color: '#f87171' }}>Unable to load anomaly alerts — please refresh.</span>
       </div>
     )
@@ -53,14 +53,14 @@ export default function AlertBar({ anomalies, loadError }) {
 
   if (!anomalies || anomalies.length === 0) {
     return (
-      <div style={styles.bar}>
+      <div style={styles.bar} role="region" aria-label="Anomaly alerts">
         <span style={styles.empty}>No active anomalies</span>
       </div>
     )
   }
 
   return (
-    <div style={styles.bar}>
+    <div style={styles.bar} role="region" aria-label="Anomaly alerts">
       {anomalies.map((a, i) => (
         <div key={a.id || i} style={styles.chip}>
           <span style={styles.dot(a.severity)} aria-hidden="true" />


### PR DESCRIPTION
## Summary

- add a stable, semantics-safe selector to `AlertBar` by marking the container as `role="region"` with `aria-label="Anomaly alerts"` in all render paths
- update existing Dashboard and AlertBar unit tests to target the AlertBar container via the new accessible selector
- keep existing message assertions so state-specific behavior remains explicit

## Testing

- `npm test -- --run src/__tests__/Dashboard.test.jsx src/__tests__/PureComponents.test.jsx`

## Notes

- The issue description mentioned `Promise.any([...])` in current tests; on `main` that pattern is no longer present, but the underlying container-selector gap was still real and is addressed here.

Closes #97

## Summary by Sourcery

Add an accessible, stable container region for the AlertBar and update tests to target it.

New Features:
- Introduce an accessible region wrapper for the AlertBar container using role and aria-label for stable selection in tests.

Tests:
- Update Dashboard and AlertBar unit tests to assert the presence of the new AlertBar region container while keeping existing message-specific assertions.