### PR TITLE
workflow: clean up stale agent-workflow labels on auto-closed issues

### DIFF
--- a/.claude/skills/review-peer-prs/SKILL.md
+++ b/.claude/skills/review-peer-prs/SKILL.md
@@ -67,8 +67,8 @@ Find GitHub issues ready for review in the peer agent queue, locate the associat
 
 - If approved:
   - Post review summary comment using `--body-file`.
-  - Update issue labels:
-    - `gh issue edit <number> --remove-label "needs-review" --add-label "reviewed:approved"`
+  - Update issue labels (remove all in-flight workflow labels to prevent stale labels after auto-close):
+    - `gh issue edit <number> --remove-label "needs-review" --remove-label "needs:changes" --add-label "reviewed:approved"`
   - Ensure required checks are green.
   - Merge PR:
     - `gh pr merge <pr-number> --merge --delete-branch`

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -14,6 +14,16 @@ Run implementation/fix/review actions in per-task git worktrees so multiple agen
 
 Run these steps in order. After each step, proceed to the next regardless of whether work was found.
 
+### Step 0 — Clean up stale labels
+
+Run once at loop startup to remove agent-workflow labels (`needs-review`, `needs:changes`) from any issues that were auto-closed by GitHub via `Closes #N` merges without the label being stripped first:
+
+```bash
+bash scripts/cleanup-stale-labels.sh
+```
+
+This prevents ghost entries from appearing in subsequent label-based queries.
+
 ### Step 1 — Fix PRs with requested changes
 
 - Run both:

--- a/scripts/cleanup-stale-labels.sh
+++ b/scripts/cleanup-stale-labels.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# cleanup-stale-labels.sh
+#
+# Remove agent-workflow labels (needs-review, needs:changes) from any
+# closed issues that still carry them.  GitHub auto-closes issues when
+# a PR with "Closes #N" is merged, but it does not strip custom labels.
+# Run this at the start of the work loop or any time label hygiene is
+# desired.
+
+set -euo pipefail
+
+LABELS=("needs-review" "needs:changes")
+
+for label in "${LABELS[@]}"; do
+  # Collect closed issue numbers that still carry this label
+  numbers=$(gh issue list --label "$label" --state closed --json number \
+            --jq '.[].number' 2>/dev/null || true)
+
+  for num in $numbers; do
+    echo "Removing stale label '$label' from closed issue #$num"
+    gh issue edit "$num" --remove-label "$label"
+  done
+done
+
+echo "Stale label cleanup complete."

--- a/skills/review-peer-prs/SKILL.md
+++ b/skills/review-peer-prs/SKILL.md
@@ -67,8 +67,8 @@ Find GitHub issues ready for review in the peer agent queue, locate the associat
 
 - If approved:
   - Post review summary comment using `--body-file`.
-  - Update issue labels:
-    - `gh issue edit <number> --remove-label "needs-review" --add-label "reviewed:approved"`
+  - Update issue labels (remove all in-flight workflow labels to prevent stale labels after auto-close):
+    - `gh issue edit <number> --remove-label "needs-review" --remove-label "needs:changes" --add-label "reviewed:approved"`
   - Ensure required checks are green.
   - Merge PR:
     - `gh pr merge <pr-number> --merge --delete-branch`

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -14,6 +14,16 @@ Run implementation/fix/review actions in per-task git worktrees so multiple agen
 
 Run these steps in order. After each step, proceed to the next regardless of whether work was found.
 
+### Step 0 — Clean up stale labels
+
+Run once at loop startup to remove agent-workflow labels (`needs-review`, `needs:changes`) from any issues that were auto-closed by GitHub via `Closes #N` merges without the label being stripped first:
+
+```bash
+bash scripts/cleanup-stale-labels.sh
+```
+
+This prevents ghost entries from appearing in subsequent label-based queries.
+
 ### Step 1 — Fix PRs with requested changes
 
 - Run both:


### PR DESCRIPTION
## Summary

- Add `scripts/cleanup-stale-labels.sh` — removes `needs-review` and `needs:changes` from any issues that were auto-closed by GitHub via `Closes #N` without explicit label removal
- Update `work/SKILL.md` — add a **Step 0** that runs the cleanup script at loop startup, preventing ghost tasks from appearing in label-based queries
- Update `review-peer-prs/SKILL.md` — also strip `needs:changes` when approving (belt-and-suspenders), so no in-flight label lingers after an issue auto-closes

## Testing

- Verified script removes stale labels from existing closed issues (#1 and #6)
- `bash scripts/cleanup-stale-labels.sh` ran successfully with correct output
- All skills pass the skill-parity pre-commit check

Closes #100

## Summary by Sourcery

Add a workflow label hygiene script and integrate it into work and review skills to prevent stale agent-workflow labels on auto-closed issues.

New Features:
- Introduce a cleanup script that removes workflow labels from closed GitHub issues that still carry agent-workflow labels.

Enhancements:
- Update work loop skills to run the label cleanup script at startup to avoid ghost entries in label-based queries.
- Update peer PR review skills to remove all in-flight workflow labels on approval to prevent stale labels after issues auto-close.