### PR TITLE
ci: enforce skill parity check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,16 @@ on:
   pull_request:
 
 jobs:
+  skill-parity-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run skill parity check
+        run: bash scripts/check-skill-parity.sh
+
   frontend-unit-tests:
+    needs: skill-parity-check
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -28,6 +37,7 @@ jobs:
         run: npm test
 
   backend-tests:
+    needs: skill-parity-check
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Summary

- add a dedicated `skill-parity-check` job that runs `bash scripts/check-skill-parity.sh`
- gate the frontend and backend test jobs on the parity job so the script runs on every PR/push

## Testing

- `bash scripts/check-skill-parity.sh`

Closes #103

## Summary by Sourcery

Add a CI job to run the skill parity check script and make test jobs depend on it.

CI:
- Introduce a dedicated skill-parity-check job that runs the skill parity validation script on each PR and push.
- Make frontend and backend test jobs depend on the skill parity check job so tests only run after parity validation passes.